### PR TITLE
Adding support to devices with assigned static IPs

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,7 +51,7 @@ type ClientListResp struct {
 			Name           string `json:"name"`
 			Online         bool   `json:"online"`
 			OwnerID        string `json:"owner_id"`
-			RemainTime     uint   `json:"remain_time"`
+			RemainTime     int   `json:"remain_time"`
 			SpaceID        string `json:"space_id"`
 			UpSpeed        uint   `json:"up_speed"`
 			WireType       string `json:"wire_type"`


### PR DESCRIPTION
RemainTime is -1 for devices with a reserved IP address. Fixing the variable type to support these situations.